### PR TITLE
Ajustement pour la phase de refroidissement avant appréciation et amélioration du README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,19 @@
 Blueprints pour Home Assistant pour utiliser l'intégration Hilo facilement. Vous allez être en mesure d'automatiser la température cible de vos thermostats pour augmenter vos récompenses Hilo
 
 ## Configuration
-
+### Intégration Hilo
 Vous allez avoir besoin de l'intégration [Hilo](https://github.com/dvd-dev/hilo) pour que ces Blueprints fonctionnent
 
-**La période d'appréciation doit être de 3 heures**
+**La période d'appréciation doit être de 3 heures. Vous pouvez le mettre dans la configuration de l'intégration Hilo**
 
+###Création d'un 'input_text'
 Créez une entrée `input_text`, ceci va stocker la phase courante des défis.
 
-* Juste ici pour la configuration: [![Open your Home Assistant instance and show your helper entities.](https://my.home-assistant.io/badges/helpers.svg)](https://my.home-assistant.io/redirect/helpers/)
+Allez dans les "helpers" pour la configuration: [![Open your Home Assistant instance and show your helper entities.](https://my.home-assistant.io/badges/helpers.svg)](https://my.home-assistant.io/redirect/helpers/)
+Choisissez "Text", donnez-lui un nom unique comme "text defi en cours" sans autre option et appuyé sur "create".
 
-Ajoutez un `sensor` dans le fichier de configuration avec ce code:
+### Creéation d'un 'Sensor'
+Ajoutez un `sensor` dans le fichier de configuration (configuration.yaml) accessible via le addon "File Editor" avec ce code:
 
 ```yaml
 template:
@@ -20,8 +23,9 @@ template:
         state: "{{ is_state('sensor.defi_hilo', ['appreciation','pre_heat','reduction','pre_cold']) }}"
 ```
 
-Redémarrez Home Assistant pour que le `sensor` devienne disponible.
+**Redémarrez Home Assistant pour que le `sensor` devienne disponible.**
 
+### Installation des "Blueprints"
 Installez les blueprints avec ces liens:
 
 * Entité de référence: [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2FEradash%2Fha-hilo-blueprints%2Fmain%2Fdefis_entite_reference.yaml)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 Blueprints pour Home Assistant pour utiliser l'intégration Hilo facilement. Vous allez être en mesure d'automatiser la température cible de vos thermostats pour augmenter vos récompenses Hilo
 
 ## Configuration
+### L'application Hilo
+Pour un fonctionnement optimal, désactivez la prise en charge des thermostats pendant les défis dans l'application Hilo. Vous participerez tout de même aux défis et recevrez les récompenses. Il est également recommandé de ne pas avoir de scènes programmées. Cela s'applique également à tous les autres thermostats non-Hilo, qui pourraient être gérés par ces automatisations.
+
 ### Intégration Hilo
 Vous allez avoir besoin de l'intégration [Hilo](https://github.com/dvd-dev/hilo) pour que ces Blueprints fonctionnent
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,10 @@ Créez une entrée `input_text`, ceci va stocker la phase courante des défis.
 Ajoutez un `sensor` dans le fichier de configuration avec ce code:
 
 ```yaml
-sensor:
-  - platform: template
-    sensors:
-      challenge_in_progress:
-        friendly_name: Senseur de défi en cours
-        value_template: "{{ is_state('sensor.defi_hilo', 'appreciation') or is_state('sensor.defi_hilo', 'pre_heat') or is_state('sensor.defi_hilo', 'reduction') }}"
+template:
+  - sensor:
+      - name: Senseur de défi en cours
+        state: "{{ is_state('sensor.defi_hilo', ['appreciation','pre_heat','reduction','pre_cold']) }}"
 ```
 
 Redémarrez Home Assistant pour que le `sensor` devienne disponible.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Vous allez avoir besoin de l'intégration [Hilo](https://github.com/dvd-dev/hilo
 
 **La période d'appréciation doit être de 3 heures. Vous pouvez le mettre dans la configuration de l'intégration Hilo**
 
-###Création d'un 'input_text'
+### Création d'un 'input_text'
 Créez une entrée `input_text`, ceci va stocker la phase courante des défis.
 
 Allez dans les "helpers" pour la configuration: [![Open your Home Assistant instance and show your helper entities.](https://my.home-assistant.io/badges/helpers.svg)](https://my.home-assistant.io/redirect/helpers/)

--- a/defis_automatiques.yaml
+++ b/defis_automatiques.yaml
@@ -211,7 +211,7 @@ action:
               - conditions:
                   condition: state
                   entity_id: !input challenge_entity
-                  state: cooling
+                  state: pre_cold
                 sequence:
                   - service: climate.set_temperature
                     data:

--- a/defis_automatiques.yaml
+++ b/defis_automatiques.yaml
@@ -49,9 +49,16 @@ blueprint:
           domain: switch
           multiple: true
 
-    bool_ref:
-      name: Défis seulement ou Défis et Appréciations 
-      description: Désactive les autres équipements durant les défis seulement (False) ou durant les défis ET les phases d'appréciation de référence (True)
+    bool_ref_water_heater:
+      name: Défis seulement ou Refroidissment et Défis 
+      description: Désactive le chauffe eaux durant les défis seulement (False) ou désactiver durant la phase de refroidissement, puis réactivation durant la phase d'appréciation avec de désactiver pour les défis (True)
+      default: False
+      selector:
+        boolean:
+        
+    bool_ref_other:
+      name: Défis seulement ou Refroidissment/Appréciations/Défis 
+      description: Désactive les autres équipements durant les défis seulement (False) ou désactiver durant la phase de refroidissement, puis réactivation durant la phase d'appréciation avec de désactiver pour les défis (True)
       default: False
       selector:
         boolean:
@@ -219,7 +226,9 @@ action:
                     target:
                       entity_id: !input thermostats
                   - choose:
-                      - conditions: "{{ water_heater|length > 0 }}"
+                      - conditions: 
+                        - "{{ water_heater|length > 0 }}"
+                        - "{{ bool_ref_water_heater == True }}"
                         sequence:
                           - service: switch.turn_off
                             target:
@@ -227,7 +236,7 @@ action:
                   - choose:
                       - conditions: 
                         - "{{ other_devices|length > 0 }}"
-                        - "{{ bool_ref == True }}"
+                        - "{{ bool_ref_other == True }}"
                         sequence:
                           - service: switch.turn_off
                             target:

--- a/defis_automatiques.yaml
+++ b/defis_automatiques.yaml
@@ -50,14 +50,14 @@ blueprint:
           multiple: true
 
     bool_ref_water_heater:
-      name: Défis seulement ou Refroidissment et Défis 
+      name: Chauffe eau - Défis seulement ou Refroidissment et Défis 
       description: Désactive le chauffe eaux durant les défis seulement (False) ou désactiver durant la phase de refroidissement, puis réactivation durant la phase d'appréciation avec de désactiver pour les défis (True)
       default: False
       selector:
         boolean:
         
     bool_ref_other:
-      name: Défis seulement ou Refroidissment/Appréciations/Défis 
+      name: Autres Équipements - Défis seulement ou Refroidissment et Défis 
       description: Désactive les autres équipements durant les défis seulement (False) ou désactiver durant la phase de refroidissement, puis réactivation durant la phase d'appréciation avec de désactiver pour les défis (True)
       default: False
       selector:

--- a/defis_entite_reference.yaml
+++ b/defis_entite_reference.yaml
@@ -104,7 +104,7 @@ action:
                 sequence:
                   - service: input_text.set_value
                     data:
-                      value: cooling
+                      value: pre_cold
                     target:
                       entity_id: !input challenge_entity
             default:


### PR DESCRIPTION
Les ajustements du README inclu les corrections de JPBARIL pour la nouvelle notation de sensor dans le fichier configuration.yaml

le sensor de defi_hilo de l'intégration utilise "pre_cold" pour le refroidissement. ce dernier n'était pas pris en charge par le blueprint ni le template sensor. donc la phase de refroidissement n'embarquait pas. 

Quelque ajout d'options et clarification pour les booleans du chauffe eau et des autres équipements